### PR TITLE
Proxy-factory to single instance per lifetime, if possible

### DIFF
--- a/src/Injectio.Attributes/RegistrationStrategy.cs
+++ b/src/Injectio.Attributes/RegistrationStrategy.cs
@@ -16,5 +16,11 @@ public enum RegistrationStrategy
     /// <summary>
     /// Registers each matching concrete type as all of its implemented interfaces and itself
     /// </summary>
-    SelfWithInterfaces = 2
+    SelfWithInterfaces = 2,
+    /// <summary>
+    /// Registers each matching concrete type as all of its implemented interfaces and itself.
+    /// For the interfaces a proxy-factory resolves the service from its type-name, so only one instance is created per lifetime
+    /// </summary>
+    /// <remarks>For open-generic registrations, this behaves like <see cref="SelfWithInterfaces"/></remarks>
+    SelfWithProxyFactory = 3
 }

--- a/src/Injectio.Generators/KnownTypes.cs
+++ b/src/Injectio.Generators/KnownTypes.cs
@@ -37,29 +37,33 @@ public static class KnownTypes
     public const string ServiceLifetimeTransientFullName = "Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient";
 
 
-    public static readonly int DuplicateStrategySkipValue = 0;
+    public const int DuplicateStrategySkipValue = 0;
     public const string DuplicateStrategySkipShortName = "Skip";
     public const string DuplicateStrategySkipTypeName = $"DuplicateStrategy.{DuplicateStrategySkipShortName}";
 
-    public static readonly int DuplicateStrategyReplaceValue = 1;
+    public const int DuplicateStrategyReplaceValue = 1;
     public const string DuplicateStrategyReplaceShortName = "Replace";
     public const string DuplicateStrategyReplaceTypeName = $"DuplicateStrategy.{DuplicateStrategyReplaceShortName}";
 
-    public static readonly int DuplicateStrategyAppendValue = 2;
+    public const int DuplicateStrategyAppendValue = 2;
     public const string DuplicateStrategyAppendShortName = "Append";
     public const string DuplicateStrategyAppendTypeName = $"DuplicateStrategy.{DuplicateStrategyAppendShortName}";
 
 
-    public static readonly int RegistrationStrategySelfValue = 0;
+    public const int RegistrationStrategySelfValue = 0;
     public const string RegistrationStrategySelfShortName = "Self";
     public const string RegistrationStrategySelfTypeName = $"RegistrationStrategy.{RegistrationStrategySelfShortName}";
 
-    public static readonly int RegistrationStrategyImplementedInterfacesValue = 1;
+    public const int RegistrationStrategyImplementedInterfacesValue = 1;
     public const string RegistrationStrategyImplementedInterfacesShortName = "ImplementedInterfaces";
     public const string RegistrationStrategyImplementedInterfacesTypeName = $"RegistrationStrategy.{RegistrationStrategyImplementedInterfacesShortName}";
 
-    public static readonly int RegistrationStrategySelfWithInterfacesValue = 2;
+    public const int RegistrationStrategySelfWithInterfacesValue = 2;
     public const string RegistrationStrategySelfWithInterfacesShortName = "SelfWithInterfaces";
     public const string RegistrationStrategySelfWithInterfacesTypeName = $"RegistrationStrategy.{RegistrationStrategySelfWithInterfacesShortName}";
+
+    public const int RegistrationStrategySelfWithProxyFactoryValue = 3;
+    public const string RegistrationStrategySelfWithProxyFactoryShortName = "SelfWithProxyFactory";
+    public const string RegistrationStrategySelfWithProxyFactoryTypeName = $"RegistrationStrategy.{RegistrationStrategySelfWithProxyFactoryShortName}";
 
 }

--- a/src/Injectio.Generators/ServiceRegistrationWriter.cs
+++ b/src/Injectio.Generators/ServiceRegistrationWriter.cs
@@ -291,6 +291,23 @@ public static class ServiceRegistrationWriter
                 .AppendIf(".", !hasNamespace)
                 .Append(serviceRegistration.Factory);
         }
+        else if (serviceRegistration.Registration == KnownTypes.RegistrationStrategySelfWithProxyFactoryShortName
+            && serviceRegistration.ImplementationType != serviceType)
+        {
+            codeBuilder
+                .AppendIf(", ", serviceRegistration.ServiceKey.HasValue())
+                .Append("(serviceProvider")
+                .AppendIf(", key", serviceRegistration.ServiceKey.HasValue())
+                .Append(") => global::Microsoft.Extensions.DependencyInjection.ServiceProvider")
+                .Append(serviceRegistration.ServiceKey.HasValue()
+                    ? "KeyedServiceExtensions.GetRequiredKeyedService<"
+                    : "ServiceExtensions.GetRequiredService<")
+                .AppendIf("global::", !serviceRegistration.ImplementationType.StartsWith("global::"))
+                .Append(serviceRegistration.ImplementationType)
+                .Append(">(serviceProvider")
+                .AppendIf(", key", serviceRegistration.ServiceKey.HasValue())
+                .Append(")");
+        }
 
         codeBuilder
             .AppendLine(")")

--- a/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterScopedSelfWithInterfaces.verified.txt
+++ b/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterScopedSelfWithInterfaces.verified.txt
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                 serviceCollection,
-                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<global::Injectio.Sample.IService, global::Injectio.Sample.SingletonService>()
+                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<global::Injectio.Sample.IService, global::Injectio.Sample.SingletonService>((serviceProvider) => global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::Injectio.Sample.SingletonService>(serviceProvider))
             );
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(

--- a/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterSingletonSelfAsClosedGeneric.verified.txt
+++ b/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterSingletonSelfAsClosedGeneric.verified.txt
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                 serviceCollection,
-                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Sample.IClosedGeneric<object>, global::Injectio.Sample.Service>()
+                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Sample.IClosedGeneric<object>, global::Injectio.Sample.Service>((serviceProvider) => global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::Injectio.Sample.Service>(serviceProvider))
             );
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(

--- a/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterSingletonTags.verified.txt
+++ b/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterSingletonTags.verified.txt
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                     serviceCollection,
-                    global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Sample.IServiceTag, global::Injectio.Sample.ServiceTag>()
+                    global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Sample.IServiceTag, global::Injectio.Sample.ServiceTag>((serviceProvider) => global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::Injectio.Sample.ServiceTag>(serviceProvider))
                 );
 
                 global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(

--- a/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterTransientSelfWithInterfaces.verified.txt
+++ b/tests/Injectio.Tests/Snapshots/ServiceRegistrationGeneratorTests.GenerateRegisterTransientSelfWithInterfaces.verified.txt
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                 serviceCollection,
-                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Transient<global::Injectio.Sample.IService, global::Injectio.Sample.SingletonService>()
+                global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Transient<global::Injectio.Sample.IService, global::Injectio.Sample.SingletonService>((serviceProvider) => global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::Injectio.Sample.SingletonService>(serviceProvider))
             );
 
             global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(


### PR DESCRIPTION
Currently e.g.

```cs
public interface IServiceTag
{
}

[RegisterSingleton(Tags = "Client,FrontEnd")]
public class ServiceTag : IServiceTag
{
}
```

yields two independent registrations, so that `provider.GetService<IServiceTag>()` and `provider.GetService<ServiceTag>()` return two independent instances, that are individually tracked and disposed. Introducing a 'factory' that resolves `ServiceTag` (implementation-type), if it is registered, and non-open-generic, to resolve `IServiceTag` solves this. Now only a single instance is created.

Generated code for the registration above with this PR is

```cs
            if (tagSet.Count == 0 || tagSet.Intersect(new[] { "Client", "FrontEnd" }).Any())
            {
                global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                    serviceCollection,
                    global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Tests.Library.IServiceTag>((serviceProvider) => global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::Injectio.Tests.Library.ServiceTag>(serviceProvider))
                );

                global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd(
                    serviceCollection,
                    global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<global::Injectio.Tests.Library.ServiceTag, global::Injectio.Tests.Library.ServiceTag>()
                );

            }
```